### PR TITLE
feat(release): auto bump tag on merged PR and publish on tag push

### DIFF
--- a/.github/workflows/auto-tag-on-main.yml
+++ b/.github/workflows/auto-tag-on-main.yml
@@ -1,0 +1,89 @@
+name: Auto tag on merged PR
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: auto-tag-main
+  cancel-in-progress: false
+
+jobs:
+  auto-tag:
+    name: Create next semantic version tag
+    runs-on:
+      - self-hosted
+      - linux
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check commit is from merged PR
+        id: pr_check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const commit_sha = context.sha;
+            const response = await github.request(
+              "GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls",
+              {
+                owner,
+                repo,
+                commit_sha,
+                mediaType: { previews: ["groot"] }
+              }
+            );
+
+            const mergedPr = response.data.find((pr) => Boolean(pr.merged_at));
+            core.setOutput("is_merged_pr", mergedPr ? "true" : "false");
+            core.setOutput("pr_number", mergedPr ? String(mergedPr.number) : "");
+
+      - name: Skip non-PR main pushes
+        if: ${{ steps.pr_check.outputs.is_merged_pr != 'true' }}
+        run: echo "Push is not associated with a merged PR, skip tagging."
+
+      - name: Compute next patch tag
+        id: next_tag
+        if: ${{ steps.pr_check.outputs.is_merged_pr == 'true' }}
+        run: |
+          git fetch --tags --force
+          latest_tag="$(git tag --list 'v*' --sort=-v:refname | head -n 1)"
+
+          if [ -z "${latest_tag}" ]; then
+            next_tag="v0.1.0"
+          else
+            if [[ ! "${latest_tag}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+              echo "Latest tag '${latest_tag}' does not match vMAJOR.MINOR.PATCH format."
+              exit 1
+            fi
+            major="${BASH_REMATCH[1]}"
+            minor="${BASH_REMATCH[2]}"
+            patch="${BASH_REMATCH[3]}"
+            next_tag="v${major}.${minor}.$((patch + 1))"
+          fi
+
+          echo "next_tag=${next_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        if: ${{ steps.pr_check.outputs.is_merged_pr == 'true' }}
+        env:
+          NEXT_TAG: ${{ steps.next_tag.outputs.next_tag }}
+          PR_NUMBER: ${{ steps.pr_check.outputs.pr_number }}
+        run: |
+          if git rev-parse "${NEXT_TAG}" >/dev/null 2>&1; then
+            echo "Tag ${NEXT_TAG} already exists, skip."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${NEXT_TAG}" -m "Release ${NEXT_TAG} (PR #${PR_NUMBER})"
+          git push origin "${NEXT_TAG}"

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,9 +1,9 @@
 name: Publish package
 
 on:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
       target:
@@ -52,7 +52,7 @@ jobs:
           python -m twine check dist/*
 
       - name: Publish to PyPI
-        if: ${{ github.event_name == 'release' || inputs.target == 'pypi' }}
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi') }}
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -492,12 +492,14 @@ uv run pytest tests/test_basic_functionality.py -v
 
 ## 🤖 GitHub Actions CI/CD（Self-hosted Runner）
 
-仓库新增了两条 GitHub Actions 工作流：
+仓库新增了三条 GitHub Actions 工作流：
 
 - `.github/workflows/ci.yml`  
   在 `push` / `pull_request` / `workflow_dispatch` 时触发，执行测试、打包和包元数据校验。
+- `.github/workflows/auto-tag-on-main.yml`  
+  在 `main` 分支收到 push 后触发，仅当该提交关联到已合并 PR 时自动创建下一个语义化 patch tag（例如 `v1.2.3 -> v1.2.4`）。
 - `.github/workflows/publish-pypi.yml`  
-  在 `release published` 时自动发布到 PyPI；也支持手动触发并选择发布到 `pypi` 或 `testpypi`。
+  在 `v*` tag push 时自动发布到 PyPI；也支持手动触发并选择发布到 `pypi` 或 `testpypi`。
 
 ### Runner 要求
 
@@ -515,7 +517,7 @@ uv run pytest tests/test_basic_functionality.py -v
 
 ### 发布方式
 
-1. 自动发布：创建 GitHub Release 并发布后，工作流会自动上传到 PyPI。  
+1. 自动发布：PR 合入 `main` 后会自动更新 tag，tag push 会触发 `Publish package` 并上传到 PyPI。  
 2. 手动发布：在 Actions 页面运行 `Publish package`，并在 `target` 里选择 `pypi` 或 `testpypi`。
 
 ## 🔧 技术特点


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Background
Need a fully automated release chain where merged PRs to `main` drive version tagging and package publishing.

## What changed
- Added `.github/workflows/auto-tag-on-main.yml`
  - Trigger: `push` on `main`
  - Runs on `self-hosted` + `linux`
  - Verifies the pushed commit is associated with a merged PR
  - Computes next semantic patch tag (`vMAJOR.MINOR.PATCH`)
  - Creates and pushes the new tag automatically
- Updated `.github/workflows/publish-pypi.yml`
  - Publish trigger switched to `push` on tags matching `v*`
  - Keeps manual `workflow_dispatch` with `pypi` / `testpypi` options
  - Uses `PYPI_TOKEN` for PyPI upload
- Updated `README.md` CI/CD section
  - Documents the new flow: PR merge -> auto tag -> publish on tag push

## Validation
- Parsed workflow YAML files via `yaml.safe_load`:
  - `.github/workflows/ci.yml`
  - `.github/workflows/auto-tag-on-main.yml`
  - `.github/workflows/publish-pypi.yml`
- `python3 -m build && python3 -m twine check dist/*` passed

## Risk
- Auto-tag currently increments patch version only.
- Tagging is skipped for direct `main` pushes that are not associated with merged PRs.

## Rollback
- Revert this PR to restore previous release behavior.

Closes #9
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f18ec10a-9aae-40b9-a9b9-33d10094e449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f18ec10a-9aae-40b9-a9b9-33d10094e449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

